### PR TITLE
Test broken with upcoming ggplot2

### DIFF
--- a/tests/testthat/test-fortify-Spat.R
+++ b/tests/testthat/test-fortify-Spat.R
@@ -72,5 +72,11 @@ test_that("Fortify SpatRasters", {
 
   build_point <- ggplot2::ggplot_build(v_point)
 
+  # ignore layout
+  build_terra$plot$layout <- NULL
+  build_point$plot$layout <- NULL
+  build_terra$layout <- NULL
+  build_point$layout <- NULL
+
   expect_identical(build_terra, build_point)
 })


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break tidyterra.

The gist of the breakage is that we've added layout in a different way to plots that breaks a plot equality test in tidyterra. In this PR, we remove the layouts before testing for equality.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help tidyterra get out a fix if necessary.