### PR TITLE
Avoid tint color shift caused by the `limits` parameter in `scale_*_hypso_tint_b` and `scale_*_hypso_tint_c`

### DIFF
--- a/R/scales_hypso.R
+++ b/R/scales_hypso.R
@@ -480,8 +480,8 @@ scale_fill_hypso_tint_c <- function(palette = "etopo1_hypso", ...,
 
   if (is.null(values)) values <- hypsocol$limit
   # Reescale
-  res <- scales::rescale(values)
   if (is.null(limits)) limits <- range(values)
+  res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_fill_gradientn(...,
     colors = hexcol,
@@ -524,8 +524,8 @@ scale_colour_hypso_tint_c <- function(palette = "etopo1_hypso", ...,
 
   if (is.null(values)) values <- hypsocol$limit
   # Reescale
-  res <- scales::rescale(values)
   if (is.null(limits)) limits <- range(values)
+  res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_colour_gradientn(...,
     colors = hexcol,
@@ -569,8 +569,8 @@ scale_fill_hypso_tint_b <- function(palette = "etopo1_hypso", ...,
 
   if (is.null(values)) values <- hypsocol$limit
   # Reescale
-  res <- scales::rescale(values)
   if (is.null(limits)) limits <- range(values)
+  res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_fill_stepsn(
     ...,
@@ -614,8 +614,8 @@ scale_colour_hypso_tint_b <- function(palette = "etopo1_hypso", ...,
 
   if (is.null(values)) values <- hypsocol$limit
   # Reescale
-  res <- scales::rescale(values)
   if (is.null(limits)) limits <- range(values)
+  res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_colour_stepsn(
     ...,


### PR DESCRIPTION
Hi!

Thanks for your excellent package. I use this package to create elevation maps, its great integrity with ggplot has massively facilitated my work.

I noticed that for the `scale_fill_hypso_tint_c` function, the elevation tinting of the plot would become inaccurate if the parameter `limits` is supplied:

```r
ggplot() +
  geom_spatraster(data = asia) +
  scale_fill_hypso_tint_c(
    palette = "gmt_globe",
    limits = c(-6000, 5000),
    # Further refinements
    breaks = c(-6000, -2000, 0, 2000, 5000),
    oob = scales::oob_squish,
    labels = c("<=-6000", "-2000", "0", "2000", ">=5000"),
    guide = guide_colorbar(reverse = TRUE)
  ) +
  labs(
    fill = "elevation (m)",
    title = "Hypsometric map of Asia"
  ) +
  theme(
    legend.position = "bottom",
    legend.title.position = "top",
    legend.key.width = rel(3),
    legend.ticks = element_line(colour = "black", linewidth = 0.3),
    legend.direction = "horizontal"
  )
```
![image](https://github.com/user-attachments/assets/26049b48-f3fb-444c-87dd-a924e50abc6a)

And I expect the result to be

![image](https://github.com/user-attachments/assets/57bd8225-7355-41b4-b5f7-1323611b3cfd)

(Here the purple color has been truncated comparing with the original palette)

The image above is plotted with a "hotfix" for the function `scale_fill_hypso_tint_c` in my the R session. This PR is the changes I made to the function, but I didn't run package builds or tests so it may need some review.