### PR TITLE
add mask for projection to avoid wrap around (fix #115)

### DIFF
--- a/R/geom_spat_contour.R
+++ b/R/geom_spat_contour.R
@@ -138,6 +138,7 @@
 #' }
 #'
 geom_spatraster_contour <- function(mapping = NULL, data,
+                                    mask_projection = FALSE,
                                     ...,
                                     maxcell = 500000,
                                     bins = NULL,
@@ -237,6 +238,7 @@ geom_spatraster_contour <- function(mapping = NULL, data,
       breaks = breaks,
       # Extra params
       maxcell = maxcell,
+      mask_projection = mask_projection,
       ...
     )
   )
@@ -290,7 +292,7 @@ StatTerraSpatRasterContour <- ggplot2::ggproto(
   default_aes = ggplot2::aes(lyr = lyr, order = after_stat(level)),
   extra_params = c(
     "maxcell", "bins", "binwidth", "breaks", "na.rm",
-    "coord_crs"
+    "coord_crs", "mask_projection"
   ),
   setup_params = function(data, params) {
     range_lys <- lapply(data$spatraster, terra::minmax)
@@ -327,12 +329,12 @@ StatTerraSpatRasterContour <- ggplot2::ggproto(
   },
   compute_group = function(data, scales, z.range, bins = NULL, binwidth = NULL,
                            breaks = NULL, na.rm = FALSE, coord,
-                           coord_crs = NA) {
+                           coord_crs = NA, mask_projection = FALSE) {
     # Extract raster from group
     rast <- data$spatraster[[1]]
 
     # Reproject if needed
-    rast <- reproject_raster_on_stat(rast, coord_crs)
+    rast <- reproject_raster_on_stat(rast, coord_crs, mask = mask_projection)
     # To data and prepare
     prepare_iso <- pivot_longer_spat(rast)
     # Keep initial data

--- a/R/geom_spat_contour_fill.R
+++ b/R/geom_spat_contour_fill.R
@@ -3,6 +3,7 @@
 #' @order 3
 #'
 geom_spatraster_contour_filled <- function(mapping = NULL, data,
+                                           mask_projection = FALSE,
                                            ...,
                                            maxcell = 500000,
                                            bins = NULL,
@@ -106,6 +107,7 @@ geom_spatraster_contour_filled <- function(mapping = NULL, data,
       breaks = breaks,
       # Extra params
       maxcell = maxcell,
+      mask_projection = mask_projection,
       ...
     )
   )
@@ -195,12 +197,12 @@ StatTerraSpatRasterContourFill <- ggplot2::ggproto(
   },
   compute_group = function(data, scales, z.range, bins = NULL, binwidth = NULL,
                            breaks = NULL, na.rm = FALSE, coord,
-                           coord_crs = NA) {
+                           coord_crs = NA, mask_projection = FALSE) {
     # Extract raster from group
     rast <- data$spatraster[[1]]
 
     # Reproject if needed
-    rast <- reproject_raster_on_stat(rast, coord_crs)
+    rast <- reproject_raster_on_stat(rast, coord_crs, mask = mask_projection)
     # To data and prepare
     prepare_iso <- pivot_longer_spat(rast)
     # Keep initial data

--- a/R/geom_spatraster.R
+++ b/R/geom_spatraster.R
@@ -31,6 +31,10 @@
 #'   an associated [coltab][terra::coltab()]. Should the coltab be used on the
 #'   plot? See also [scale_fill_coltab()].
 #'
+#' @param mask_projection logical, defaults to FALSE. If TRUE, mask out areas outside the input extent.
+#' For example, to avoid data wrapping around the date-line. This is passed to
+#' [terra::project()] when reprojecting the `SpatRaster`.
+#'
 #' @inheritParams ggplot2::geom_raster
 #'
 #' @source
@@ -142,6 +146,7 @@ geom_spatraster <- function(mapping = aes(),
                             interpolate = FALSE,
                             maxcell = 500000,
                             use_coltab = TRUE,
+                            mask_projection = FALSE,
                             ...) {
   if (!inherits(data, "SpatRaster")) {
     cli::cli_abort(paste(
@@ -219,6 +224,7 @@ geom_spatraster <- function(mapping = aes(),
       # Extra params
       maxcell = maxcell,
       interpolate = interpolate,
+      mask_projection = mask_projection,
       ...
     )
   )
@@ -263,7 +269,7 @@ StatTerraSpatRaster <- ggplot2::ggproto(
     lyr = lyr, group = lyr,
     spatraster = after_stat(spatraster)
   ),
-  extra_params = c("maxcell", "na.rm", "coord_crs"),
+  extra_params = c("maxcell", "na.rm", "coord_crs", "mask_projection"),
   compute_layer = function(self, data, params, layout) {
     # warn if not using facets
     if (length(unique(data$PANEL)) != length(unique(data$lyr))) {
@@ -293,12 +299,12 @@ StatTerraSpatRaster <- ggplot2::ggproto(
     )
   },
   compute_group = function(data, scales, coord, params,
-                           coord_crs = NA) {
+                           coord_crs = NA, mask_projection = FALSE) {
     # Extract raster from group
     rast <- data$spatraster[[1]]
 
     # Reproject if needed
-    rast <- reproject_raster_on_stat(rast, coord_crs)
+    rast <- reproject_raster_on_stat(rast, coord_crs, mask = mask_projection)
 
     # To data and prepare
     data_end <- pivot_longer_spat(rast)
@@ -325,7 +331,8 @@ remove_columns <- function(x, rem) {
 
 # Reproject a SpatRaster with params
 reproject_raster_on_stat <- function(raster,
-                                     coords_crs = NA) {
+                                     coords_crs = NA,
+                                     mask = FALSE) {
   # Check if need to reproject
   crs_terra <- pull_crs(raster)
 
@@ -355,7 +362,8 @@ reproject_raster_on_stat <- function(raster,
   # Create template for projection
   template <- terra::project(
     terra::rast(init_rast),
-    coord_crs
+    coord_crs,
+    mask = mask
   )
 
   # Try to keep the same number of cells on the template
@@ -366,7 +374,7 @@ reproject_raster_on_stat <- function(raster,
 
 
   # Reproject
-  proj_rast <- terra::project(init_rast, template)
+  proj_rast <- terra::project(init_rast, template, mask = mask)
 
   return(proj_rast)
 }

--- a/R/geom_spatraster.R
+++ b/R/geom_spatraster.R
@@ -31,8 +31,10 @@
 #'   an associated [coltab][terra::coltab()]. Should the coltab be used on the
 #'   plot? See also [scale_fill_coltab()].
 #'
-#' @param mask_projection logical, defaults to FALSE. If TRUE, mask out areas outside the input extent.
-#' For example, to avoid data wrapping around the date-line. This is passed to
+#' @param mask_projection logical, defaults to FALSE. If TRUE, mask out areas
+#' outside the input extent.
+#' For example, to avoid data wrapping around the date-line in Equal Area
+#' projections. This parameter is passed to
 #' [terra::project()] when reprojecting the `SpatRaster`.
 #'
 #' @inheritParams ggplot2::geom_raster

--- a/R/geom_spatraster_rgb.R
+++ b/R/geom_spatraster_rgb.R
@@ -28,7 +28,6 @@
 #' @param max_col_value Number giving the maximum of the color values range.
 #'   When this is `255` (the default), the result is computed most efficiently.
 #'   See [grDevices::rgb()].
-#'
 #' @seealso
 #' [ggplot2::geom_raster()], [ggplot2::coord_sf()], [grDevices::rgb()].
 #'
@@ -83,6 +82,7 @@ geom_spatraster_rgb <- function(mapping = aes(),
                                 alpha = 1,
                                 maxcell = 500000,
                                 max_col_value = 255,
+                                mask_projection = FALSE,
                                 ...,
                                 stretch = NULL,
                                 zlim = NULL) {
@@ -157,6 +157,7 @@ geom_spatraster_rgb <- function(mapping = aes(),
       interpolate = interpolate,
       max_col_value = max_col_value,
       alpha = alpha,
+      mask_projection = mask_projection,
       ...
     )
   )
@@ -189,7 +190,7 @@ StatTerraSpatRasterRGB <- ggplot2::ggproto(
   "StatTerraSpatRasterRGB",
   ggplot2::Stat,
   required_aes = "spatraster",
-  extra_params = c("maxcell", "max_col_value", "na.rm"),
+  extra_params = c("maxcell", "max_col_value", "na.rm", "mask_projection"),
   compute_layer = function(self, data, params, layout) {
     # add coord to the params, so it can be forwarded to compute_group()
     params$coord_crs <- pull_crs(layout$coord_params$crs)
@@ -201,12 +202,13 @@ StatTerraSpatRasterRGB <- ggplot2::ggproto(
   },
   compute_group = function(data, scales, coord, params,
                            coord_crs = NA,
-                           max_col_value = 255) {
+                           max_col_value = 255,
+                           mask_projection = FALSE) {
     # Extract raster from group
     rast <- data$spatraster[[1]]
 
     # Reproject if needed
-    rast <- reproject_raster_on_stat(rast, coord_crs)
+    rast <- reproject_raster_on_stat(rast, coord_crs, mask = mask_projection)
 
     # To data and prepare
     data_end <- make_hexcol(rast, max_col_value)

--- a/man/geom_spat_contour.Rd
+++ b/man/geom_spat_contour.Rd
@@ -11,6 +11,7 @@
 geom_spatraster_contour(
   mapping = NULL,
   data,
+  mask_projection = FALSE,
   ...,
   maxcell = 5e+05,
   bins = NULL,
@@ -40,6 +41,7 @@ geom_spatraster_contour_text(
 geom_spatraster_contour_filled(
   mapping = NULL,
   data,
+  mask_projection = FALSE,
   ...,
   maxcell = 5e+05,
   bins = NULL,
@@ -55,6 +57,12 @@ geom_spatraster_contour_filled(
 \strong{Aesthetics} specially in the use of \code{fill} aesthetic.}
 
 \item{data}{A \code{SpatRaster} object.}
+
+\item{mask_projection}{logical, defaults to FALSE. If TRUE, mask out areas
+outside the input extent.
+For example, to avoid data wrapping around the date-line in Equal Area
+projections. This parameter is passed to
+\code{\link[terra:project]{terra::project()}} when reprojecting the \code{SpatRaster}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
 arguments broadly fall into one of 4 categories below. Notably, further

--- a/man/geom_spatraster.Rd
+++ b/man/geom_spatraster.Rd
@@ -18,6 +18,7 @@ geom_spatraster(
   interpolate = FALSE,
   maxcell = 5e+05,
   use_coltab = TRUE,
+  mask_projection = FALSE,
   ...
 )
 
@@ -59,6 +60,10 @@ the plot.}
 \item{use_coltab}{Logical. Only applicable to \code{SpatRaster} objects that have
 an associated \link[terra:colors]{coltab}. Should the coltab be used on the
 plot? See also \code{\link[=scale_fill_coltab]{scale_fill_coltab()}}.}
+
+\item{mask_projection}{logical, defaults to FALSE. If TRUE, mask out areas outside the input extent.
+For example, to avoid data wrapping around the date-line. This is passed to
+\code{\link[terra:project]{terra::project()}} when reprojecting the \code{SpatRaster}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
 arguments broadly fall into one of 4 categories below. Notably, further

--- a/man/geom_spatraster.Rd
+++ b/man/geom_spatraster.Rd
@@ -61,8 +61,10 @@ the plot.}
 an associated \link[terra:colors]{coltab}. Should the coltab be used on the
 plot? See also \code{\link[=scale_fill_coltab]{scale_fill_coltab()}}.}
 
-\item{mask_projection}{logical, defaults to FALSE. If TRUE, mask out areas outside the input extent.
-For example, to avoid data wrapping around the date-line. This is passed to
+\item{mask_projection}{logical, defaults to FALSE. If TRUE, mask out areas
+outside the input extent.
+For example, to avoid data wrapping around the date-line in Equal Area
+projections. This parameter is passed to
 \code{\link[terra:project]{terra::project()}} when reprojecting the \code{SpatRaster}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These

--- a/man/geom_spatraster_rgb.Rd
+++ b/man/geom_spatraster_rgb.Rd
@@ -18,6 +18,7 @@ geom_spatraster_rgb(
   alpha = 1,
   maxcell = 5e+05,
   max_col_value = 255,
+  mask_projection = FALSE,
   ...,
   stretch = NULL,
   zlim = NULL
@@ -43,6 +44,12 @@ the plot.}
 \item{max_col_value}{Number giving the maximum of the color values range.
 When this is \code{255} (the default), the result is computed most efficiently.
 See \code{\link[grDevices:rgb]{grDevices::rgb()}}.}
+
+\item{mask_projection}{logical, defaults to FALSE. If TRUE, mask out areas
+outside the input extent.
+For example, to avoid data wrapping around the date-line in Equal Area
+projections. This parameter is passed to
+\code{\link[terra:project]{terra::project()}} when reprojecting the \code{SpatRaster}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
 arguments broadly fall into one of 4 categories below. Notably, further


### PR DESCRIPTION
By passing "mask_projection" to "terra::project()" we can deal with projections that will wrap around the 180 longitude line (such as the Equal Earth projection). As a simple reprex:
```r
library(geodata)
library(tidyterra)
library(ggplot2)
#sample data
tavg <- worldclim_global("tavg", 10, ".")
tavg <- mean(tavg)
ggplot() +
  geom_spatraster(data = tavg, mask_projection = TRUE) +
  scale_fill_whitebox_c(palette='atlas') +
  coord_sf(crs = "+proj=eqearth") + 
  labs(title='Equal Earth')
```
![image](https://github.com/user-attachments/assets/8ad6c202-dd9f-4406-93f6-5c4f3ba2d921)

fix #115 
