### PR TITLE
allow one-sided limit in `scale_*_tint_*()`

### DIFF
--- a/R/scales_cross_blended.R
+++ b/R/scales_cross_blended.R
@@ -491,8 +491,10 @@ scale_fill_cross_blended_tint_c <- function(palette = "cold_humid", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_fill_gradientn(...,
@@ -536,8 +538,10 @@ scale_colour_cross_blended_tint_c <- function(palette = "cold_humid", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_colour_gradientn(...,
@@ -581,8 +585,10 @@ scale_fill_cross_blended_tint_b <- function(palette = "cold_humid", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_fill_stepsn(
@@ -627,8 +633,10 @@ scale_colour_cross_blended_tint_b <- function(palette = "cold_humid", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_colour_stepsn(

--- a/R/scales_grass.R
+++ b/R/scales_grass.R
@@ -243,8 +243,10 @@ scale_fill_grass_c <- function(palette = "viridis", ...,
     if (!is.null(values)) res <- scales::rescale(res)
   } else {
     if (is.null(values)) values <- hypsocol$limit
+    if (anyNA(values)) values <- values[!is.na(values)]
     # Reescale
     if (is.null(limits)) limits <- range(values)
+    if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
     res <- scales::rescale(values, from = limits)
   }
 
@@ -296,8 +298,10 @@ scale_colour_grass_c <- function(palette = "viridis", ...,
     if (!is.null(values)) res <- scales::rescale(res)
   } else {
     if (is.null(values)) values <- hypsocol$limit
+    if (anyNA(values)) values <- values[!is.na(values)]
     # Reescale
     if (is.null(limits)) limits <- range(values)
+    if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
     res <- scales::rescale(values, from = limits)
   }
 
@@ -354,8 +358,10 @@ scale_fill_grass_b <- function(palette = "viridis", ...,
     if (!is.null(values)) res <- scales::rescale(res)
   } else {
     if (is.null(values)) values <- hypsocol$limit
+    if (anyNA(values)) values <- values[!is.na(values)]
     # Reescale
     if (is.null(limits)) limits <- range(values)
+    if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
     res <- scales::rescale(values, from = limits)
   }
 
@@ -408,8 +414,10 @@ scale_colour_grass_b <- function(palette = "viridis", ...,
     if (!is.null(values)) res <- scales::rescale(res)
   } else {
     if (is.null(values)) values <- hypsocol$limit
+    if (anyNA(values)) values <- values[!is.na(values)]
     # Reescale
     if (is.null(limits)) limits <- range(values)
+    if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
     res <- scales::rescale(values, from = limits)
   }
 

--- a/R/scales_hypso.R
+++ b/R/scales_hypso.R
@@ -470,8 +470,10 @@ scale_fill_hypso_tint_c <- function(palette = "etopo1_hypso", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_fill_gradientn(...,
@@ -514,8 +516,10 @@ scale_colour_hypso_tint_c <- function(palette = "etopo1_hypso", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_colour_gradientn(...,
@@ -559,8 +563,10 @@ scale_fill_hypso_tint_b <- function(palette = "etopo1_hypso", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_fill_stepsn(
@@ -604,8 +610,10 @@ scale_colour_hypso_tint_b <- function(palette = "etopo1_hypso", ...,
   if (alpha != 1) hexcol <- ggplot2::alpha(hexcol, alpha = alpha)
 
   if (is.null(values)) values <- hypsocol$limit
+  if (anyNA(values)) values <- values[!is.na(values)]
   # Reescale
   if (is.null(limits)) limits <- range(values)
+  if (anyNA(limits)) limits[is.na(limits)] <- range(values)[is.na(limits)]
   res <- scales::rescale(values, from = limits)
 
   ggplot2::scale_colour_stepsn(


### PR DESCRIPTION
Allowing `limits=c(lower_limit, NA)` or `limits=c(NA, upper_limit)` in `scale_*_tint_*()` functions.

For example, `scale_fill_hypso_tint_c("gmt_globe", limits=c(0,NA))` will get the same effect as `scale_fill_hypso_tint_c("gmt_globe_hypso")`