### PR TITLE
Support alpha layers in geom_spatraster

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - The pkgdown site now links to the JOSS paper as an external article and uses
   `vignette("tidyterra")` as the introductory article.
 - `geom_spatraster()`, `geom_spatraster_rgb()`, `geom_spatraster_contour()`, `geom_spatraster_contour_text()`, `stat_spatraster()`, `tidy()` and `fortify()` now consistently accept `maxcell = Inf` and validate related arguments earlier.
+- `geom_spatraster()` and `stat_spatraster(geom = "raster")` now support mapping `alpha` to a different `SpatRaster` layer than `fill` (#154, #211).
 - `geom_spatraster_rgb()` no longer emits a warning for rasters with more than
   three layers, such as RGB rasters with an alpha channel.
 - Default aesthetics in `geom_*` functions adjusted to current **ggplot2**

--- a/R/geom-spat-contour.R
+++ b/R/geom-spat-contour.R
@@ -28,6 +28,8 @@
 #' @inheritParams geom_spatraster
 #' @inheritParams ggplot2::geom_contour
 #' @inheritParams ggplot2::geom_text
+#' @param mapping Set of aesthetic mappings created by [ggplot2::aes()]. See
+#'   **Aesthetics** for supported contour aesthetics.
 #'
 #' @returns A \CRANpkg{ggplot2} layer.
 #' @section \CRANpkg{terra} equivalent:

--- a/R/geom-spat-contour.R
+++ b/R/geom-spat-contour.R
@@ -44,6 +44,7 @@
 #' - [`group`][ggplot2::aes_group_order]
 #' - [`linetype`][ggplot2::aes_linetype_size_shape]
 #' - [`linewidth`][ggplot2::aes_linetype_size_shape]
+#' - `weight`
 #'
 #' `geom_spatraster_contour_text()` also understands:
 #'

--- a/R/geom-spatraster.R
+++ b/R/geom-spatraster.R
@@ -25,7 +25,8 @@
 #' @param data A `SpatRaster` object.
 #'
 #' @param mapping Set of aesthetic mappings created by [ggplot2::aes()]. See
-#'   **Aesthetics**, especially in the use of the `fill` aesthetic.
+#'   **Aesthetics**, especially the use of the `fill` and `alpha` aesthetics
+#'   with `SpatRaster` layers.
 #'
 #' @param na.rm If `TRUE`, the default, missing values are silently removed. If
 #'   `FALSE`, missing values are removed with a warning.
@@ -83,8 +84,10 @@
 #'
 #' `fill` can use computed variables.
 #'
-#' For `alpha`, use a computed variable or the name of one layer that is present
-#' on the `SpatRaster`. See section **Computed variables**.
+#' For `alpha`, use a computed variable or the name of one layer that is
+#' present on the `SpatRaster`. When `alpha` is a layer name, it can refer to
+#' the same layer as `fill` or to another layer in the `SpatRaster`. See section
+#' **Computed variables**.
 #'
 #' @section Facets:
 #'

--- a/R/geom-spatraster.R
+++ b/R/geom-spatraster.R
@@ -83,7 +83,8 @@
 #'
 #' `fill` can use computed variables.
 #'
-#' For `alpha`, use a computed variable. See section **Computed variables**.
+#' For `alpha`, use a computed variable or the name of one layer that is present
+#' on the `SpatRaster`. See section **Computed variables**.
 #'
 #' @section Facets:
 #'
@@ -97,6 +98,8 @@
 #' [ggplot2::after_stat()]).
 #'
 #' - `after_stat(value)`: Cell values of the `SpatRaster`.
+#' - `after_stat(alpha)`: Cell values of the layer mapped to `alpha`, when
+#'   `alpha` is the name of a layer.
 #' - `after_stat(lyr)`: Name of the layer.
 #'
 #' @encoding UTF-8
@@ -179,6 +182,13 @@ geom_spatraster <- function(
   # Use prepared data.
   mapping <- prepared$map
 
+  # Keep the alpha layer separate from the displayed layer. This allows users to
+  # map `fill` and `alpha` to different raster layers.
+  alpha_data <- NULL
+  if (is_character(prepared$alphalayer)) {
+    alpha_data <- terra::subset(data, prepared$alphalayer)
+  }
+
   # Check whether the `SpatRaster` needs to be subset.
   if (is_character(prepared$namelayer)) {
     # Subset the layer from the data.
@@ -190,13 +200,16 @@ geom_spatraster <- function(
   data <- check_mixed_cols(data)
 
   data <- resample_spat(data, maxcell)
+  if (!is_null(alpha_data)) {
+    alpha_data <- resample_spat(alpha_data, maxcell, inform = FALSE)
+  }
 
   # 3. Create a nested list with each layer----
   raster_list <- as.list(data)
 
   # Create the data frame.
   data_tbl <- tibble::tibble(
-    spatraster = list(NULL),
+    spatraster = vector("list", terra::nlyr(data)),
     # Keep layer order when faceting.
     lyr = factor(names(data), levels = names(data))
   )
@@ -226,6 +239,7 @@ geom_spatraster <- function(
       # Extra params
       maxcell = maxcell,
       interpolate = interpolate,
+      alpha_spatraster = alpha_data,
       mask_projection = mask_projection,
       ...
     )
@@ -264,7 +278,13 @@ StatTerraSpatRaster <- ggplot2::ggproto(
     group = lyr,
     spatraster = after_stat(spatraster)
   ),
-  extra_params = c("maxcell", "na.rm", "coord_crs", "mask_projection"),
+  extra_params = c(
+    "maxcell",
+    "na.rm",
+    "coord_crs",
+    "alpha_spatraster",
+    "mask_projection"
+  ),
   compute_layer = function(self, data, params, layout) {
     warn_overlapping_layers(data, "geom_spatraster")
     # Add the coordinate CRS so it can be forwarded to `compute_group()`.
@@ -281,6 +301,7 @@ StatTerraSpatRaster <- ggplot2::ggproto(
     coord,
     params,
     coord_crs = NA,
+    alpha_spatraster = NULL,
     mask_projection = FALSE
   ) {
     # Extract the raster from the current group.
@@ -288,9 +309,24 @@ StatTerraSpatRaster <- ggplot2::ggproto(
 
     # Reproject if needed.
     rast <- reproject_raster_on_stat(rast, coord_crs, mask = mask_projection)
+    alpha_rast <- alpha_spatraster
+    if (!is_null(alpha_rast)) {
+      alpha_rast <- prepare_alpha_spatraster(
+        alpha_rast,
+        rast,
+        coord_crs,
+        mask = mask_projection
+      )
+    }
 
     # Convert to a data frame and prepare output.
     data_end <- pivot_longer_spat(rast)
+    if (!is_null(alpha_rast)) {
+      alpha_tbl <- pivot_longer_spat(alpha_rast)
+      alpha_tbl <- remove_columns(alpha_tbl, "lyr")
+      names(alpha_tbl)[names(alpha_tbl) == "value"] <- "alpha"
+      data_end <- dplyr::left_join(data_end, alpha_tbl, by = c("x", "y"))
+    }
     data_rest <- data
 
     # Drop the raster payload before joining to reduce the output size.
@@ -355,6 +391,27 @@ reproject_raster_on_stat <- function(raster, coords_crs = NA, mask = FALSE) {
   proj_rast
 }
 
+prepare_alpha_spatraster <- function(
+  alpha_rast,
+  template_rast,
+  coord_crs = NA,
+  mask = FALSE
+) {
+  alpha_rast <- reproject_raster_on_stat(alpha_rast, coord_crs, mask = mask)
+
+  same_geom <- terra::compareGeom(
+    alpha_rast,
+    template_rast,
+    stopOnError = FALSE
+  )
+
+  if (isTRUE(same_geom)) {
+    return(alpha_rast)
+  }
+
+  terra::resample(alpha_rast, template_rast)
+}
+
 pivot_longer_spat <- function(x) {
   tb <- as_tbl_internal(x)
   tb_pivot <- tidyr::pivot_longer(tb, -c(1, 2), names_to = "lyr")
@@ -413,13 +470,15 @@ select_spatraster_layer <- function(
   )
 }
 
-resample_spat <- function(r, maxcell = 50000) {
+resample_spat <- function(r, maxcell = 50000, inform = TRUE) {
   if (terra::ncell(r) > 1.1 * maxcell) {
     r <- terra::spatSample(r, maxcell, as.raster = TRUE, method = "regular")
-    cli::cli_inform(paste(
-      "{.cls SpatRaster} resampled to",
-      "{.val {terra::ncell(r)}} cell{?s}."
-    ))
+    if (isTRUE(inform)) {
+      cli::cli_inform(paste(
+        "{.cls SpatRaster} resampled to",
+        "{.val {terra::ncell(r)}} cell{?s}."
+      ))
+    }
   }
 
   r
@@ -493,44 +552,52 @@ prepare_aes_spatraster <- function(
 
   # Create the default result object first, this may be overridden.
 
-  result_obj <- list(namelayer = FALSE, map = mapinit)
+  result_obj <- list(namelayer = FALSE, alphalayer = FALSE, map = mapinit)
 
   # Capture all info
   fill_from_dots <- "fill" %in% names(dots)
+  alpha_from_dots <- "alpha" %in% names(dots)
 
   # Do nothing if fill in dots
-  if (isTRUE(fill_from_dots)) {
-    return(result_obj)
+  if (!isTRUE(fill_from_dots)) {
+    # Extract from aes
+    fill_from_aes <- unname(vapply(mapinit, rlang::as_label, character(1))[
+      "fill"
+    ])
+    fill_not_provided <- is_na(fill_from_aes)
+    is_layer <- fill_from_aes %in% raster_names
+
+    # If not provided add after_stat
+    if (fill_not_provided) {
+      result_obj$map <- override_aesthetics(
+        mapinit,
+        ggplot2::aes(fill = after_stat(.data$value))
+      )
+    }
+
+    # If it is a layer need to override the fill value and keep the namelayer
+    if (is_layer) {
+      result_obj$map <- override_aesthetics(
+        ggplot2::aes(fill = after_stat(.data$value)),
+        result_obj$map
+      )
+      result_obj$namelayer <- fill_from_aes
+    }
   }
 
-  # Extract from aes
-  fill_from_aes <- unname(vapply(mapinit, rlang::as_label, character(1))[
-    "fill"
-  ])
-  fill_not_provided <- is_na(fill_from_aes)
-  is_layer <- fill_from_aes %in% raster_names
+  if (!isTRUE(alpha_from_dots)) {
+    alpha_from_aes <- unname(vapply(mapinit, rlang::as_label, character(1))[
+      "alpha"
+    ])
+    is_alpha_layer <- alpha_from_aes %in% raster_names
 
-  # If not provided add after_stat
-  if (fill_not_provided) {
-    map_not_prov <- override_aesthetics(
-      mapinit,
-      ggplot2::aes(fill = after_stat(.data$value))
-    )
-
-    result_obj$map <- map_not_prov
-    return(result_obj)
-  }
-
-  # If it is a layer need to override the fill value and keep the namelayer
-  if (is_layer) {
-    map_layer <- override_aesthetics(
-      ggplot2::aes(fill = after_stat(.data$value)),
-      mapinit
-    )
-
-    result_obj$map <- map_layer
-    result_obj$namelayer <- fill_from_aes
-    return(result_obj)
+    if (is_alpha_layer) {
+      result_obj$map <- override_aesthetics(
+        ggplot2::aes(alpha = after_stat(.data$alpha)),
+        result_obj$map
+      )
+      result_obj$alphalayer <- alpha_from_aes
+    }
   }
 
   # Otherwise leave as it is

--- a/R/stat-spatraster.R
+++ b/R/stat-spatraster.R
@@ -25,10 +25,11 @@
 #' - [`fill`][ggplot2::aes_colour_fill_alpha]
 #' - [`alpha`][ggplot2::aes_colour_fill_alpha]
 #'
-#' When `geom = "raster"`, the `fill` argument behaves as in
-#' `geom_spatraster()`. If another `geom` is used, `stat_spatraster()`
-#' understands the aesthetics required by that `geom`, so
-#' `aes(fill = <name_of_lyr>)` is not applicable.
+#' When `geom = "raster"`, the `fill` and `alpha` arguments behave as in
+#' `geom_spatraster()`, so they can be mapped to `SpatRaster` layer names. If
+#' another `geom` is used, `stat_spatraster()` understands the aesthetics
+#' required by that `geom`, so `aes(fill = <name_of_lyr>)` and
+#' `aes(alpha = <name_of_lyr>)` are not applicable.
 #'
 #' The `x` and `y` aesthetics are mapped by default, so you do not need to add
 #' them in `aes()`. In every case, aesthetics should be mapped with computed

--- a/R/stat-spatraster.R
+++ b/R/stat-spatraster.R
@@ -116,11 +116,18 @@ stat_spatraster <- function(
     # Use prepared data.
     mapping <- prepared$map
 
+    alpha_data <- NULL
+    if (is_character(prepared$alphalayer)) {
+      alpha_data <- terra::subset(data, prepared$alphalayer)
+    }
+
     # Check whether the `SpatRaster` needs to be subset.
     if (is_character(prepared$namelayer)) {
       # Subset the layer from the data.
       data <- terra::subset(data, prepared$namelayer)
     }
+  } else {
+    alpha_data <- NULL
   }
   # 2. Check if resample is needed----
 
@@ -128,13 +135,16 @@ stat_spatraster <- function(
   data <- check_mixed_cols(data)
 
   data <- resample_spat(data, maxcell)
+  if (!is_null(alpha_data)) {
+    alpha_data <- resample_spat(alpha_data, maxcell, inform = FALSE)
+  }
 
   # 3. Create a nested list with each layer----
   raster_list <- as.list(data)
 
   # Create the data frame.
   data_tbl <- tibble::tibble(
-    spatraster = list(NULL),
+    spatraster = vector("list", terra::nlyr(data)),
     # Keep layer order when faceting.
     lyr = factor(names(data), levels = names(data))
   )
@@ -163,6 +173,7 @@ stat_spatraster <- function(
       na.rm = na.rm,
       # Extra params
       maxcell = maxcell,
+      alpha_spatraster = alpha_data,
       ...
     )
   )

--- a/man/geom_spat_contour.Rd
+++ b/man/geom_spat_contour.Rd
@@ -173,6 +173,7 @@ the following aesthetics:
 \item \code{\link[ggplot2:aes_group_order]{group}}
 \item \code{\link[ggplot2:aes_linetype_size_shape]{linetype}}
 \item \code{\link[ggplot2:aes_linetype_size_shape]{linewidth}}
+\item \code{weight}
 }
 
 \code{geom_spatraster_contour_text()} also understands:

--- a/man/geom_spat_contour.Rd
+++ b/man/geom_spat_contour.Rd
@@ -56,7 +56,7 @@ geom_spatraster_contour_filled(
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{ggplot2::aes()}}. See
-\strong{Aesthetics}, especially in the use of the \code{fill} aesthetic.}
+\strong{Aesthetics} for supported contour aesthetics.}
 
 \item{data}{A \code{SpatRaster} object.}
 

--- a/man/geom_spatraster.Rd
+++ b/man/geom_spatraster.Rd
@@ -36,7 +36,8 @@ stat_spatraster(
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{ggplot2::aes()}}. See
-\strong{Aesthetics}, especially in the use of the \code{fill} aesthetic.}
+\strong{Aesthetics}, especially the use of the \code{fill} and \code{alpha} aesthetics
+with \code{SpatRaster} layers.}
 
 \item{data}{A \code{SpatRaster} object.}
 
@@ -160,8 +161,10 @@ mapped \code{fill} aesthetic.
 
 \code{fill} can use computed variables.
 
-For \code{alpha}, use a computed variable or the name of one layer that is present
-on the \code{SpatRaster}. See section \strong{Computed variables}.
+For \code{alpha}, use a computed variable or the name of one layer that is
+present on the \code{SpatRaster}. When \code{alpha} is a layer name, it can refer to
+the same layer as \code{fill} or to another layer in the \code{SpatRaster}. See section
+\strong{Computed variables}.
 
 
 \subsection{\code{stat_spatraster()}}{
@@ -173,10 +176,11 @@ when \code{geom = "raster"} (the default):
 \item \code{\link[ggplot2:aes_colour_fill_alpha]{alpha}}
 }
 
-When \code{geom = "raster"}, the \code{fill} argument behaves as in
-\code{geom_spatraster()}. If another \code{geom} is used, \code{stat_spatraster()}
-understands the aesthetics required by that \code{geom}, so
-\verb{aes(fill = <name_of_lyr>)} is not applicable.
+When \code{geom = "raster"}, the \code{fill} and \code{alpha} arguments behave as in
+\code{geom_spatraster()}, so they can be mapped to \code{SpatRaster} layer names. If
+another \code{geom} is used, \code{stat_spatraster()} understands the aesthetics
+required by that \code{geom}, so \verb{aes(fill = <name_of_lyr>)} and
+\verb{aes(alpha = <name_of_lyr>)} are not applicable.
 
 The \code{x} and \code{y} aesthetics are mapped by default, so you do not need to add
 them in \code{aes()}. In every case, aesthetics should be mapped with computed

--- a/man/geom_spatraster.Rd
+++ b/man/geom_spatraster.Rd
@@ -160,7 +160,8 @@ mapped \code{fill} aesthetic.
 
 \code{fill} can use computed variables.
 
-For \code{alpha}, use a computed variable. See section \strong{Computed variables}.
+For \code{alpha}, use a computed variable or the name of one layer that is present
+on the \code{SpatRaster}. See section \strong{Computed variables}.
 
 
 \subsection{\code{stat_spatraster()}}{
@@ -198,6 +199,8 @@ aesthetics, using (for example) \code{aes(alpha = after_stat(value))} (see
 \code{\link[ggplot2:after_stat]{ggplot2::after_stat()}}).
 \itemize{
 \item \code{after_stat(value)}: Cell values of the \code{SpatRaster}.
+\item \code{after_stat(alpha)}: Cell values of the layer mapped to \code{alpha}, when
+\code{alpha} is the name of a layer.
 \item \code{after_stat(lyr)}: Name of the layer.
 }
 }

--- a/tests/testthat/test-geom-spatraster.R
+++ b/tests/testthat/test-geom-spatraster.R
@@ -47,6 +47,83 @@ test_that("Regular tests", {
   expect_silent(ss <- ggplot2::ggplot_build(s))
   expect_identical(unique(ss$data[[1]]$lyr), "tavg_04")
 
+  # Named alpha layer
+  alpha_r <- terra::rast(ncols = 2, nrows = 2, nlyr = 2)
+  names(alpha_r) <- c("fill_layer", "alpha_layer")
+  terra::values(alpha_r) <- data.frame(
+    fill_layer = 1:4,
+    alpha_layer = c(0.2, 0.4, 0.6, 0.8)
+  )
+
+  alpha_plot <- ggplot2::ggplot() +
+    geom_spatraster(
+      data = alpha_r,
+      aes(fill = fill_layer, alpha = alpha_layer)
+    ) +
+    ggplot2::scale_alpha_identity()
+
+  alpha_data <- ggplot2::layer_data(alpha_plot)
+  expect_identical(unique(alpha_data$lyr), "fill_layer")
+  alpha_values <- alpha_data[
+    order(alpha_data$x, alpha_data$y),
+    c(
+      "value",
+      "alpha"
+    )
+  ]
+  row.names(alpha_values) <- NULL
+  expect_equal(
+    alpha_values,
+    data.frame(
+      value = c(3, 1, 4, 2),
+      alpha = c(0.6, 0.2, 0.8, 0.4)
+    )
+  )
+
+  stat_alpha_plot <- ggplot2::ggplot() +
+    stat_spatraster(
+      data = alpha_r,
+      aes(fill = fill_layer, alpha = alpha_layer)
+    ) +
+    ggplot2::scale_alpha_identity()
+
+  stat_alpha_data <- ggplot2::layer_data(stat_alpha_plot)
+  expect_equal(
+    stat_alpha_data[order(stat_alpha_data$x, stat_alpha_data$y), "alpha"],
+    c(0.6, 0.2, 0.8, 0.4)
+  )
+
+  set.seed(154)
+  x <- terra::rast(array(data = rnorm(120, 0, 1), dim = c(5, 5, 2)))
+  names(x) <- c("prediction", "se")
+  xdf <- as.data.frame(x, xy = TRUE)
+
+  tile_plot <- ggplot2::ggplot() +
+    ggplot2::geom_tile(
+      data = xdf,
+      aes(x = x, y = y, fill = se, alpha = prediction)
+    ) +
+    ggplot2::scale_alpha_continuous(range = c(0, 1))
+
+  spat_plot <- ggplot2::ggplot() +
+    geom_spatraster(data = x, aes(fill = se, alpha = prediction)) +
+    ggplot2::scale_alpha_continuous(range = c(0, 1))
+
+  tile_data <- ggplot2::layer_data(tile_plot)
+  spat_data <- ggplot2::layer_data(spat_plot)
+  tile_alpha <- tile_data[
+    order(tile_data$x, tile_data$y),
+    c("x", "y", "alpha")
+  ]
+  spat_alpha <- spat_data[
+    order(spat_data$x, spat_data$y),
+    c("x", "y", "alpha")
+  ]
+  row.names(tile_alpha) <- NULL
+  row.names(spat_alpha) <- NULL
+
+  expect_equal(spat_alpha, tile_alpha)
+
   # Resampled
   s1 <- terra::subset(r, 1)
 
@@ -147,4 +224,26 @@ test_that("Helpers", {
     list()
   )
   expect_false(prepared$namelayer)
+
+  prepared_alpha <- prepare_aes_spatraster(
+    ggplot2::aes(fill = lyr.1, alpha = lyr.2),
+    c("lyr.1", "lyr.2"),
+    list()
+  )
+  expect_identical(prepared_alpha$namelayer, "lyr.1")
+  expect_identical(prepared_alpha$alphalayer, "lyr.2")
+
+  alpha_rast <- terra::rast(ncols = 4, nrows = 4)
+  terra::values(alpha_rast) <- seq_len(terra::ncell(alpha_rast))
+  terra::crs(alpha_rast) <- ""
+  template_rast <- terra::rast(ncols = 2, nrows = 2)
+  terra::values(template_rast) <- seq_len(terra::ncell(template_rast))
+  terra::crs(template_rast) <- ""
+
+  aligned_alpha <- prepare_alpha_spatraster(alpha_rast, template_rast)
+  expect_true(terra::compareGeom(
+    aligned_alpha,
+    template_rast,
+    stopOnError = FALSE
+  ))
 })

--- a/tests/testthat/test-stat-spatraster.R
+++ b/tests/testthat/test-stat-spatraster.R
@@ -44,6 +44,27 @@ test_that("Minimal checks for stat_spatraster 1lyr CRS", {
 
   expect_s3_class(p_aes, "ggplot")
 
+  alpha_r <- rast(ncols = 2, nrows = 2, nlyr = 2)
+  names(alpha_r) <- c("fill_layer", "alpha_layer")
+  values(alpha_r) <- data.frame(
+    fill_layer = 1:4,
+    alpha_layer = c(0.2, 0.4, 0.6, 0.8)
+  )
+
+  p_alpha <- ggplot() +
+    stat_spatraster(
+      data = alpha_r,
+      aes(fill = fill_layer, alpha = alpha_layer)
+    ) +
+    scale_alpha_identity()
+
+  alpha_data <- layer_data(p_alpha)
+  expect_identical(unique(alpha_data$lyr), "fill_layer")
+  expect_equal(
+    alpha_data[order(alpha_data$x, alpha_data$y), "alpha"],
+    c(0.6, 0.2, 0.8, 0.4)
+  )
+
   # change geom
   p <- ggplot() +
     stat_spatraster(data = r, geom = "point", aes(fill = elevation_m))


### PR DESCRIPTION
## Summary

- Allow `geom_spatraster()` and `stat_spatraster(geom = "raster")` to map `alpha` to a `SpatRaster` layer different from the `fill` layer.
- Reproject and align the alpha layer with the rendered raster layer when needed.
- Add `layer_data()` tests comparing the computed `alpha` values against `ggplot2::geom_tile()`.
- Document the change in `NEWS.md` for #154 and #211.
- Align `geom_spatraster_contour()` aesthetics documentation with ggplot2's `geom_contour()` by documenting `weight`.

## Other geoms

- `geom_spatraster_contour()` and `geom_spatraster_contour_filled()` use ggplot2 contour semantics, where the raster layer is the `z` source for derived contour lines or bands. Mapping a second raster layer to `alpha` or `fill` there would not match ggplot2's documented contour aesthetics, so this PR only aligns the documented contour aesthetic list.
- `geom_spatraster_rgb()` already has RGB-specific aesthetics and is not affected by this `fill`/`alpha` layer mapping issue.

## Validation

- `air format .` (unrelated pre-existing format churn discarded)
- `devtools::load_all(); devtools::lint()`
- `jarl check .`
- `devtools::test(filter = '^geom-spatraster$|^stat-spatraster$')`
- `devtools::test_coverage_active_file('R/geom-spatraster.R')`
- `devtools::test_coverage_active_file('R/stat-spatraster.R')`

Fixes #154.